### PR TITLE
Fix tests failing with Pydantic 2.7.0

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,7 @@
 import pytest
-
+from pydantic import ConfigDict
 from testapp.models import Configuration, Listing, Preference, Record, Searchable
 
-from pydantic import ConfigDict
 from djantic import ModelSchema
 
 
@@ -273,7 +272,11 @@ def test_enum_choices():
     }
 
     preference = Preference.objects.create(
-        name="Jordan", preferred_sport="", preferred_musician=None
+        name="Jordan",
+        preferred_food="ba",
+        preferred_group=1,
+        preferred_sport="",
+        preferred_musician=None,
     )
     assert PreferenceSchema.from_django(preference).model_dump() == {
         "id": 1,


### PR DESCRIPTION
Fixes #3 

We tried to validate the enum values (`preferred_food` and `preferred_group`) before creating an instance of the `Preference` model in the database. This was causing validation errors because the test was passing invalid enum values directly to the `PreferenceSchema`.