### PR TITLE
Allow related fields to be nullable

### DIFF
--- a/djantic/main.py
+++ b/djantic/main.py
@@ -1,4 +1,5 @@
 import inspect
+from enum import Enum
 from functools import reduce
 from itertools import chain
 from typing import Any, Dict, List, Optional, no_type_check, Union
@@ -172,6 +173,8 @@ class ProxyGetterNestedObj:
             attr = list(attr.all())
         elif outer_type_ == int and issubclass(type(attr), Model):
             attr = attr.id
+        elif inspect.isclass(type(attr)) and issubclass(type(attr), Enum):
+            attr = attr.value
         elif issubclass(attr.__class__, ImageFieldFile) and issubclass(
             outer_type_, str
         ):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -308,7 +308,7 @@ def test_listing():
         model_config = ConfigDict(model=Listing, use_enum_values=True)
 
     assert ListingSchema.model_json_schema() == {
-        "description": "Listing(id, items)",
+        "description": "Listing(id, items, content_type)",
         "properties": {
             "id": {
                 "anyOf": [{"type": "integer"}, {"type": "null"}],
@@ -322,6 +322,12 @@ def test_listing():
                 "title": "Items",
                 "type": "array",
             },
+            "content_type": {
+                "anyOf": [{"type": "integer"}, {"type": "null"}],
+                "default": None,
+                "description": "id",
+                "title": "Content Type",
+            },
         },
         "required": ["items"],
         "title": "ListingSchema",
@@ -330,6 +336,7 @@ def test_listing():
 
     preference = Listing(items=["a", "b"])
     assert ListingSchema.from_django(preference).dict() == {
+        "content_type": None,
         "id": None,
         "items": ["a", "b"],
     }

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -281,3 +281,4 @@ class Case(ExtendedModel):
 
 class Listing(models.Model):
     items = ArrayField(models.TextField(), size=4)
+    content_type = models.ForeignKey(ContentType, on_delete=models.PROTECT, blank=True, null=True)


### PR DESCRIPTION
- Allow related fields to be nullable by checking `blank` or `null` kwargs and adding `Union[type, None]`
- Fix Enum representation by returning the `myvar.value` instead of the enum itself