### PR TITLE
OneToOne and ManyToMany models are nullable

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,8 +1,36 @@
 import pytest
 from pydantic import ConfigDict
-from testapp.models import Configuration, Listing, Preference, Record, Searchable
+from testapp.models import Configuration, Listing, Preference, Record, Searchable, User
 
 from djantic import ModelSchema
+
+
+@pytest.mark.django_db
+def test_schema_without_include_and_exclude():
+    """
+    Using a schema without include and exclude populates userschema correctly
+    Optional foreign key handled gracefully.
+    """
+
+    user = User.objects.create(
+        first_name="Jordan", last_name="Eremieff", email="jordan@eremieff.com"
+    )
+
+    class UserSchema(ModelSchema):
+        model_config = ConfigDict(model=User)
+
+    dumped = UserSchema.from_django(user).model_dump()
+    # These values are here, but a hassle to use freeze gun.
+    dumped.pop("updated_at")
+    dumped.pop("created_at")
+
+    assert dumped == {
+        "first_name": "Jordan",
+        "id": 1,
+        "email": "jordan@eremieff.com",
+        "profile": None,
+        "last_name": "Eremieff",
+    }
 
 
 @pytest.mark.django_db

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -364,10 +364,17 @@ def test_one_to_one():
                 "description": "A user of the application.",
                 "properties": {
                     "profile": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                            },
+                            {
+                                "type": "null",
+                            },
+                        ],
                         "default": None,
                         "description": "id",
                         "title": "Profile",
-                        "type": "integer",
                     },
                     "id": {
                         "anyOf": [{"type": "integer"}, {"type": "null"}],


### PR DESCRIPTION
These foreign key relationships should be nullable and as such this should be reflected in the schema and when making a model instance into a schema.

Prior to this this would throw an error, as it was not recognized as nullable.