### PR TITLE
BUGFIX: allow nullable FKS

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -282,3 +282,11 @@ class Case(ExtendedModel):
 class Listing(models.Model):
     items = ArrayField(models.TextField(), size=4)
     content_type = models.ForeignKey(ContentType, on_delete=models.PROTECT, blank=True, null=True)
+
+
+class A(models.Model):
+    value = models.CharField(max_length=256, null=True, blank=True)
+
+
+class B(models.Model):
+    a = models.ForeignKey(A, null=True, blank=True, on_delete=models.CASCADE)


### PR DESCRIPTION
In the case of a model with a nullable foreign key to another model the `from_django` method does not currently work.

I've added a check for Optional types in the `dict` method, which extracts the correct type


```
class A(models.Model):
    value = models.CharField(max_length=256, null=True, blank=True)


class B(models.Model):
    a = models.ForeignKey(A, null=True, blank=True, on_delete=models.CASCADE)
```